### PR TITLE
Fix Compass dependency

### DIFF
--- a/SassyStrings.gemspec
+++ b/SassyStrings.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |s|
   s.files += Dir.glob("stylesheets/**/*.*")
   # Dependent Gems
   s.add_dependency("sass",      [">=3.3"])
-  s.add_dependency("compass",   [">=1.0.0"])
+  s.add_dependency("compass",   [">=1.0.0.alpha.18"])
 end


### PR DESCRIPTION
Compass 1.0.0 has not been released yet, so gem installation was failing.

Please also bump the version on SassyStrings and push a new gem.
